### PR TITLE
Add support for DataFlex 20.0. To use this version with DataFlex 14.1…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@ A hash table class for Dataflex that supports values of any type, from basic typ
 
 Supported and tested on DataFlex 14.1-20.0, it most likely works on more versions.
 
+If you are using DataFlex 14.1-18.0, add a use statement for [DFCompatibilityLayer](https://github.com/ekstrom/DFCompatibilityLayer). It includes the function StringToUCharArray, which does not exist in DataFlex 14.1-18.0.
+
 ## Code Examples
 
 ```dataflex
 Use cHashTable.pkg
-
-// Optional: If you are using DataFlex 14.1-18.0, add a use statement for [DFCompatibilityLayer](https://github.com/ekstrom/DFCompatibilityLayer)
-// It includes the function StringToUCharArray, which does not exist in DataFlex 14.1-18.0
-Use DFCompatibilityLayer.pkg
 
 ...
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # cHashTable
-A hash table class for Dataflex that supports values of any type, from basic types to structs and arrays. Since the Dataflex standard library doesn't include a dictionary type, you are free and safe to download and use this library if you need one. It's been around since 2013 and is actively maintained in 2020.
+
+A hash table class for Dataflex that supports values of any type, from basic types to structs and arrays. Since the Dataflex standard library doesn't include a dictionary type, you are free and safe to download and use this library if you need one. It's been around since 2013 and is actively maintained in 2021.
+
+Supported and tested on DataFlex 14.1-20.0, it most likely works on more versions.
 
 ## Code Examples
 
 ```dataflex
 Use cHashTable.pkg
+
+// Optional: If you are using DataFlex 14.1-18.0, add a use statement for [DFCompatibilityLayer](https://github.com/ekstrom/DFCompatibilityLayer)
+// It includes the function StringToUCharArray, which does not exist in DataFlex 14.1-18.0
+Use DFCompatibilityLayer.pkg
 
 ...
 

--- a/cHashTable.pkg
+++ b/cHashTable.pkg
@@ -139,17 +139,14 @@ Class cHashTable is a cObject
     { Visibility=Private }
     Function _Hash String s Integer iMod Returns Integer
         BigInt hash
-        Integer i
-        Char[] ca
-        Address aStr
+        Integer i iLastIndex
+        UChar[] uca
         Move 5381 to hash
-        Move (ResizeArray(ca,Length(s)+1)) to ca
-        Move (AddressOf(ca)) to aStr
-        Move s to aStr
-        Repeat
-            Move ((33 * hash) + ca[i]) to hash
-            Increment i
-        Until (ca[i] = 0)
+        Move (StringToUCharArray(s)) to uca
+        Move (SizeOfArray(uca) - 1) to iLastIndex
+        For i from 0 to iLastIndex
+            Move ((33 * hash) + uca[i]) to hash
+        Loop
         If (hash > 0) Function_Return (hash - (iMod * (hash / iMod)))
         Else Function_Return (iMod + (hash - (iMod * (hash / iMod))) - 1)
     End_Function


### PR DESCRIPTION
…-18.0, add a use statement to DFCompatibilityLayer.pkg, it includes the function StringToUCharArray, which does not exist in DataFlex 14.1-18.0. This change was tested on DataFlex 14.1, 19.1 and 20.0.